### PR TITLE
Fix for issue:Left edge of stats for projects is cut off when viewing on iPad 2

### DIFF
--- a/app/views/Project/show.html.php
+++ b/app/views/Project/show.html.php
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row-fluid">
 	<div class="page-header">
 		<h1>
 			Stats for project: <small><?=$this->project->name?></small>
@@ -73,22 +73,25 @@
             </div>
             <div class="clearfix"></div>
         </div>
-    	<div class="span6 pull-left">
-    		<h2>Popularity over time</h2>
-    		<div class="well" id="main-stats" style="height:300px;">
-    		</div>
-    	</div>
-    	<div class="span6 pull-left">
-    		<h2>Commits activity</h2>
-    		<div class="well " id="commits-stats" style="height:300px;">
-    		</div>
-    	</div>
-    	<div class="clearfix"></div>
-    	<div class="span12">
-    		<h2>Pull requests activity</h2>
-    		<div class="well " id="pull-stats" style="height:400px;">
-    		</div>
-    	</div>
+        <div class="stats-container">	
+            <div class="span6 pull-left">
+        		<h2>Popularity over time</h2>
+        		<div class="well" id="main-stats" style="height:300px;">
+        		</div>
+        	</div>
+        	<div class="span6 pull-left">
+        		<h2>Commits activity</h2>
+        		<div class="well " id="commits-stats" style="height:300px;">
+        		</div>
+        	</div>
+        </div>
+        <div class="stats-container">	
+            <div class="span12">
+        		<h2>Pull requests activity</h2>
+        		<div class="well " id="pull-stats" style="height:400px;">
+        		</div>
+        	</div>
+        </div>    
     </div>
     <div class="well tab-pane" id="readme">
     <?=MarkdownExtra::defaultTransform($this->project->readme)?>

--- a/app/views/layout/layout.html.php
+++ b/app/views/layout/layout.html.php
@@ -59,7 +59,7 @@ UserVoice.push(['showTab', 'classic_widget', {
   <div class="container">
     <?php
     if(user_logged_in()) { ?>
-    <div class="row">
+    <div class="row-fluid">
       <div class="top-nav">
         <span class="app-name">
         <!--  Looking For Pull Requests-->
@@ -97,7 +97,7 @@ UserVoice.push(['showTab', 'classic_widget', {
     <?php
     }
     ?>
-    <div class="row">
+    <div class="row-fluid">
       <?= $this->renderView(); ?>
     </div>
     </div>

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -366,6 +366,7 @@ pointer-events: none;
 
 #project-data-panel {
   position: relative;
+  padding-left: 2.5em;
 }
 
 .pr_acceptance_rate {


### PR DESCRIPTION
https://github.com/deleteman/lfpr/issues/50
Left edge of stats for projects is cut off when viewing on iPad 2 #50
