### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/public/javascripts/highcharts/exporting-server/phantomjs/readme.md
+++ b/public/javascripts/highcharts/exporting-server/phantomjs/readme.md
@@ -1,10 +1,10 @@
-#The Highcharts image convert script#
+# The Highcharts image convert script #
 The file highcharts-convert.js is a [PhantomJS](http://phantomjs.org/) script to convert SVG or Highcharts JSON options objects to chart images. It is ideal for batch processing Highcharts configurations for attaching to emails or reports. It is also used in the featured export server, where it is referenced by a PHP file. An online demo with a GUI can be viewed at [export.highcharts.com/demo.php](http://export.highcharts.com/demo.php).
 
-#Example usage#
+# Example usage #
 	phantomjs highcharts-convert.js -infile options1.json -outfile chart1.png -scale 2.5 -width 300 -constr Chart -callback callback.js
 
-#Description of command line parameters#
+# Description of command line parameters #
 
 **-infile:** The file to convert, assumes it's either a JSON file, the script checks for the input file to have the extension '.json', or otherwise it assumes it to be an svg file.
 

--- a/readme.md
+++ b/readme.md
@@ -2,34 +2,34 @@ Looking For Pull Requests
 =====================
 The site where you can find possible projects to contribute to, or even publish your own projects and let others find it and help you!.
 
-##Using LFPR
+## Using LFPR
 
 Using the site is dead simple, if you're just browsing, click on the "Find projects" button on the home page, and you'll be redirected to the main list of published projects. If you're interested in a particular programming language you can filter by it.
 
 If you're looking to publish your project and let others find it, just click on the "Publish your project" button on the main page. You'll be redirected to a page, where you'll be invited to enter the project's URL (only works for projects hosted on Github) and after clicking on the "Query" button, all relevant information will be pulled using Github's API. Just click on "Send info" after that, and you'll be all set.
 
-##What's inside it?
+## What's inside it?
 
 Apart from listing repos, LFPR is daily pulling statistics of those projects from GitHub, trying to display in a graphical manner, how "alive" that project is, because, lets be honest, if you're going to spend your time contributing to someone else's project, you want to make sure that, at least, it's still under development, otherwise, you'll probably sending pull requests that will never be answered.
 
-##Contributing to the project.
+## Contributing to the project.
 
 This project has a lot more features coming, specially related to project and user statistics, so if you feel like contributing, just go the it's repo, create a ticket and we'll go from there :)
 
 OR, you can just email me at: deleteman[at]gmail[dot]com 
 
-###Running the site locally
+### Running the site locally
 
 If you're planning on cloning the site and running it locally, follow these simple steps:
 
-####Pre requirements
+#### Pre requirements
 
 1. Install Apache 2
 2. Install MySQL 5 
 3. Install PHP 5  (with cli package and mysql package)
 4. Install PHP CURL module
 
-####Actual steps
+#### Actual steps
 
 1. Clone the repo
 2. Create a `tmp` directory on the project directory (and make sure it's writable by apache)
@@ -74,7 +74,7 @@ If you're planning on cloning the site and running it locally, follow these simp
 
 
 
-###Contributing
+### Contributing
 
 If you feel like helping out by bug-fixing, or contributing with a new feature or whatever, just follow these simple steps:
 
@@ -85,6 +85,6 @@ If you feel like helping out by bug-fixing, or contributing with a new feature o
 5. Be happy :)
 
 
-##More?
+## More?
 
 Wanna know more about the author? Check out my other repos at: https://github.com/deleteman


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
